### PR TITLE
Dockerfile: install new eldk-5.6 toolchain with existing toolchain from new branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,18 @@ RUN dpkg --add-architecture i386 && apt-get update && apt-get install --yes \
 RUN ln -sf /usr/bin/lua5.3 /usr/bin/lua \
   && ln -sf /usr/bin/nodejs /usr/bin/node
 
-RUN git clone --depth=1 --branch eldk https://github.com/wsbu/toolchain-ram.git /eldk \
-  && yes | /eldk/eldk/install -d /opt/eldk/4.2 arm \
+RUN git clone --depth=1 --progress --verbose --branch binaries \
+  https://github.com/wsbu/toolchain-ram.git /binaries \
+  && yes | /binaries/eldk/install -d /opt/eldk/4.2 arm \
   && ln -sf 4.2/arm /opt/eldk/arm \
-  && rm -rf /eldk
+  && cp -r /binaries/eldk-5.6 /opt \
+  && rm -rf /binaries
+
+ENV WSBU_C11_COMPILER /opt/eldk-5.6/armv5te/sysroots/i686-eldk-linux/usr/bin/arm-linux-gnueabi/arm-linux-gnueabi-g++
+ENV WSBU_C11_FLAGS \
+  -isystem /opt/eldk-5.6/armv5te/sysroots/armv5te-linux-gnueabi/usr/include \
+  -isystem /opt/eldk-5.6/armv5te/sysroots/armv5te-linux-gnueabi/usr/include/c++ \
+  -isystem /opt/eldk-5.6/armv5te/sysroots/armv5te-linux-gnueabi/usr/include/c++/arm-linux-gnueabi
 
 # Lots of things complain if we are homeless
 ENV HOME /home/captain


### PR DESCRIPTION
The eldk toolchain is from http://ftp.denx.de/pub/eldk/5.6/iso/eldk-5.6-armv5te.iso

Installed using included installer:

    ./install.sh -s toolchain armv5te

Then removed usr/src as well as all .debug folders to reduce size